### PR TITLE
Working around the issue https://github.com/jitpack/jitpack.io/issues/2189

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,11 @@ sonarRunner {
     }
 }
 
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+artifacts {
+    archives sourcesJar
+}


### PR DESCRIPTION
To cut it short: gradle is not being able to download the HtmlSpanner dependency from Jitpack anymore (it gets completely stuck trying to download the sources jar from Jitpack, which is not there, and the requests never even times out).
A workaround is to add the sources jar configuration so the file is there and the download goes just fine.