### PR TITLE
Handle `text-align` style attribute correctly

### DIFF
--- a/src/main/java/net/nightwhistler/htmlspanner/handlers/attributes/AlignmentAttributeHandler.java
+++ b/src/main/java/net/nightwhistler/htmlspanner/handlers/attributes/AlignmentAttributeHandler.java
@@ -41,6 +41,12 @@ public class AlignmentAttributeHandler extends WrappingStyleHandler {
 			int start, int end, Style style, SpanStack spanStack) {
 		
 		String align = node.getAttributeByName("align");
+		if (align == null) {
+		    final String style = node.getAttributeByName("style");
+		    if (style != null && style.contains("text-align:")) {
+		        align = style.split("text-align:")[1].split(";")[0].trim();
+		    }
+		}
 
 		if ( "right".equalsIgnoreCase(align) ) {
 		    style = style.setTextAlignment(Style.TextAlignment.RIGHT);


### PR DESCRIPTION
Sometimes, the `style` attribute is used for formatting. Handle alignments in that case as well...

```
<p style="text-align:center;">Some text...</p>
```