### PR TITLE
implement contrast patcher

### DIFF
--- a/src/main/java/net/nightwhistler/htmlspanner/ContrastPatcher.java
+++ b/src/main/java/net/nightwhistler/htmlspanner/ContrastPatcher.java
@@ -1,0 +1,12 @@
+package net.nightwhistler.htmlspanner;
+
+import net.nightwhistler.htmlspanner.style.Style;
+
+public interface ContrastPatcher {
+
+    Integer patchBackgroundColor(final Style style);
+
+    Integer patchFontColor(final Style style);
+
+
+}

--- a/src/main/java/net/nightwhistler/htmlspanner/HtmlSpanner.java
+++ b/src/main/java/net/nightwhistler/htmlspanner/HtmlSpanner.java
@@ -72,6 +72,18 @@ public class HtmlSpanner {
 
     private FontResolver fontResolver;
 
+    private ContrastPatcher contrastPatcher = new ContrastPatcher() {
+        @Override
+        public Integer patchBackgroundColor(Style style) {
+            return style.getBackgroundColor();
+        }
+
+        @Override
+        public Integer patchFontColor(Style style) {
+            return style.getColor();
+        }
+    };
+
     /**
      * Switch to determine if CSS is used
      */
@@ -134,6 +146,24 @@ public class HtmlSpanner {
      */
     public boolean isStripExtraWhiteSpace() {
         return stripExtraWhiteSpace;
+    }
+
+    /**
+     * Update the ContrastPatcher instance
+     *
+     * @param patcher
+     */
+    public void setContrastPatcher(ContrastPatcher patcher) {
+        this.contrastPatcher = patcher;
+    }
+
+    /**
+     * Returns the ContrastPatcher instance which might will modify the font/background color
+     *
+     * @return
+     */
+    public ContrastPatcher getContrastPatcher() {
+        return this.contrastPatcher;
     }
 
     /**

--- a/src/main/java/net/nightwhistler/htmlspanner/handlers/attributes/BorderAttributeHandler.java
+++ b/src/main/java/net/nightwhistler/htmlspanner/handlers/attributes/BorderAttributeHandler.java
@@ -28,7 +28,7 @@ public class BorderAttributeHandler extends WrappingStyleHandler {
 
         if ( node.getAttributeByName("border") != null ) {
             Log.d("BorderAttributeHandler", "Adding BorderSpan from " + start + " to " + end);
-            spanStack.pushSpan(new BorderSpan(useStyle, start, end, getSpanner().isUseColoursFromStyle() ), start, end);
+            spanStack.pushSpan(new BorderSpan(useStyle, start, end, getSpanner()), start, end);
         }
 
         super.handleTagNode(node, builder, start, end, useStyle, spanStack);

--- a/src/main/java/net/nightwhistler/htmlspanner/spans/BorderSpan.java
+++ b/src/main/java/net/nightwhistler/htmlspanner/spans/BorderSpan.java
@@ -27,14 +27,14 @@ public class BorderSpan implements LineBackgroundSpan {
 
     private Style style;
 
-    private boolean usecolour;
+    private HtmlSpanner spanner;
 
-    public BorderSpan( Style style, int start, int end, boolean usecolour ) {
+    public BorderSpan( Style style, int start, int end, HtmlSpanner spanner ) {
         this.start = start;
         this.end = end;
 
         this.style = style;
-        this.usecolour = usecolour;
+        this.spanner = spanner;
     }
 
 
@@ -69,14 +69,15 @@ public class BorderSpan implements LineBackgroundSpan {
         int originalColor = p.getColor();
         float originalStrokeWidth = p.getStrokeWidth();
 
-        if ( usecolour && style.getBackgroundColor() != null ) {
-            p.setColor(style.getBackgroundColor());
+        Integer backgroundColor = spanner.getContrastPatcher().patchBackgroundColor(style);
+        if ( spanner.isUseColoursFromStyle() && backgroundColor != null ) {
+            p.setColor(backgroundColor);
             p.setStyle(Paint.Style.FILL);
 
             c.drawRect(left,top,right,bottom,p);
         }
 
-        if ( usecolour && style.getBorderColor() != null ) {
+        if ( spanner.isUseColoursFromStyle() && style.getBorderColor() != null ) {
             p.setColor( style.getBorderColor() );
         }
 
@@ -113,4 +114,3 @@ public class BorderSpan implements LineBackgroundSpan {
 
 
 }
-

--- a/src/main/java/net/nightwhistler/htmlspanner/style/StyleCallback.java
+++ b/src/main/java/net/nightwhistler/htmlspanner/style/StyleCallback.java
@@ -69,15 +69,16 @@ public class StyleCallback implements SpanCallback {
         }
 
         //If there's no border, we use a BackgroundColorSpan to draw colour behind the text
-        if ( spanner.isUseColoursFromStyle() &&  useStyle.getBackgroundColor() != null  && useStyle.getBorderStyle() == null ) {
-            //Log.d("StyleCallback", "Applying BackgroundColorSpan with color " + useStyle.getBackgroundColor() + " from " + start + " to " + end + " on text " + builder.subSequence(start, end));
-              builder.setSpan(new BackgroundColorSpan(useStyle.getBackgroundColor()), start, end,
+        final Integer backgroundColor = spanner.getContrastPatcher().patchBackgroundColor(useStyle);
+        if ( spanner.isUseColoursFromStyle() &&  backgroundColor != null  && useStyle.getBorderStyle() == null ) {
+            //Log.d("StyleCallback", "Applying BackgroundColorSpan with color " + backgroundColor + " from " + start + " to " + end + " on text " + builder.subSequence(start, end));
+              builder.setSpan(new BackgroundColorSpan(backgroundColor), start, end,
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
         //If there is a border, the BorderSpan will also draw the background colour if needed.
         if ( useStyle.getBorderStyle() != null ) {
-            builder.setSpan(new BorderSpan(useStyle, start, end, spanner.isUseColoursFromStyle()), start, end,
+            builder.setSpan(new BorderSpan(useStyle, start, end, spanner), start, end,
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
@@ -100,9 +101,10 @@ public class StyleCallback implements SpanCallback {
             }
         }
 
-        if ( spanner.isUseColoursFromStyle() && useStyle.getColor() != null ) {
+        final Integer fontColor = spanner.getContrastPatcher().patchFontColor(useStyle);
+        if ( spanner.isUseColoursFromStyle() && fontColor != null ) {
             //Log.d("StyleCallback", "Applying ForegroundColorSpan from " + start + " to " + end + " on text " + builder.subSequence(start, end) );
-            builder.setSpan(new ForegroundColorSpan(useStyle.getColor()), start, end,
+            builder.setSpan(new ForegroundColorSpan(fontColor), start, end,
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 


### PR DESCRIPTION
Useful e.g. for rendering dark theme versions of the HTML

This will change nothing about the default rendering experience, but will allow apps to patch the font color if wanted... 

Use case:
A black font color on transparent background will be invisible in dark theme. However, the app could add a contrast check to convert a black font color to white if necessary, but leave all other colors unchanged. More advanced contrast handling are possible as well, of course...