### PR TITLE
Move to htmlcleaner 2.26 to get security fix for CVE-2021-33813

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 apply plugin: 'android-library'
 
 dependencies {
-    compile 'net.sourceforge.htmlcleaner:htmlcleaner:2.16'
+    compile 'net.sourceforge.htmlcleaner:htmlcleaner:2.26'
     compile 'com.osbcp.cssparser:cssparser:1.5'
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
 		<groupId>net.sourceforge.htmlcleaner</groupId>
 		<artifactId>htmlcleaner</artifactId>
-		<version>2.2</version>       
+		<version>2.26</version>       
      </dependency>
 
     <dependency>


### PR DESCRIPTION
htmlcleaner versions prior to 2.26 had a high rated security issue

https://nvd.nist.gov/vuln/detail/CVE-2021-33813